### PR TITLE
fix: Print newline to stderr as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ pub struct ProgressBar {
 impl Drop for ProgressBar {
     fn drop(&mut self) {
         self.redraw();
-        println!();
+        eprintln!();
     }
 }
 


### PR DESCRIPTION
Previously, the progress bar was output to stderr but once finished, the newline was written to stdout. This causes empty lines to appear in stdout and the progress bar to finish incorrectly in stderr.