### PR TITLE
fix: Respect `should_draw` in `impl Drop`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,8 +466,10 @@ pub struct ProgressBar {
 
 impl Drop for ProgressBar {
     fn drop(&mut self) {
-        self.redraw();
-        eprintln!();
+        if (self.active_config().should_draw)() {
+            self.redraw();
+            eprintln!();
+        }
     }
 }
 


### PR DESCRIPTION
Previously, the progress bar was drawn once, even when `should_draw` returned `false`.